### PR TITLE
driver-pipo-x8-script fixes.

### DIFF
--- a/driver-pipo-x8-script.sh
+++ b/driver-pipo-x8-script.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 # This script fetch, compile, install and configure additional drivers
 # needed by Pipo X8 with Debian 8 installed. Main reference to this
 # work could be found on https://wiki.debian.org/InstallingDebianOn/PIPO/PIPO%20X8
@@ -8,7 +8,7 @@ ORIG_DIR="$(pwd)"
 
 function _configure_repos() {
 	# Backports for Jessie, needed for newer kernel
-	echo "deb http://ftp.es.debian.org/debian/ jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list
+	echo "deb http://httpredir.debian.org/debian/ jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list
 	apt update
 }
 
@@ -20,30 +20,43 @@ function _install_packages() {
 
 # Touchscreen, free driver
 function _touchscreen() {
-	KERNEL_TARGET="4.6.0-0.bpo.1-amd64"
+	test -z "$KERNEL_TARGET" &&
+	    KERNEL_TARGET="$(apt-cache search --names-only ^linux-image- | awk '/.bpo./ {print $1; exit}' | sed 's,^linux-image-,,')"
 	# Check if needed packages are installed
 	_configure_repos
-	_install_packages build-essential linux-image-$KERNEL_TARGET/jessie-backports linux-headers-$KERNEL_TARGET/jessie-backports  linux-base/jessie-backports
+	_install_packages \
+		build-essential \
+		linux-image-$KERNEL_TARGET/jessie-backports \
+		linux-headers-$KERNEL_TARGET/jessie-backports \
+		linux-base/jessie-backports
 
-	# This module has to be compiled and patched	
+	# This module has to be compiled and patched
 	cd /usr/src
-	mkdir driver-touchscreen
-	cd driver-touchscreen
+	rm -rf driver-touchscreen
+	mkdir  driver-touchscreen
+	cd     driver-touchscreen
 	wget "http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/plain/drivers/input/touchscreen/goodix.c"
 
 	wget "https://raw.githubusercontent.com/Librerouter/Librekernel/gh-pages/driver-pipo-x8-script-files/0001-Input-goodix-add-changes-to-support-PIPO-X8.patch"
-	cat 0001-Input-goodix-add-changes-to-support-PIPO-X8.patch | patch
+	cat 0001-Input-goodix-add-changes-to-support-PIPO-X8.patch | patch -b
 
-	echo -e "obj-m += goodix.o\nall:\n\tmake -C /lib/modules/$KERNEL_TARGET/build M=\$(PWD) modules\nclean:\n\tmake -C /lib/modules/$KERNEL_TARGET/build M=\$(PWD) clean" > Makefile
+	echo "
+obj-m += goodix.o
+all:
+	make -C /lib/modules/$KERNEL_TARGET/build M=\$(PWD) modules
+clean:
+	make -C /lib/modules/$KERNEL_TARGET/build M=\$(PWD) clean
+" > Makefile
 	make
-	#echo -n 'file gpiolib.c +p' > /sys/kernel/debug/dynamic_debug/control
+	#echo -n 'file gpiolib.c +p'      > /sys/kernel/debug/dynamic_debug/control
 	#echo -n 'file gpiolib-acpi.c +p' > /sys/kernel/debug/dynamic_debug/control
-	#echo -n 'file property.c +p' > /sys/kernel/debug/dynamic_debug/control
+	#echo -n 'file property.c +p'     > /sys/kernel/debug/dynamic_debug/control
 	# Moving compiled module to proper path
-	cp goodix.ko /lib/modules/${KERNEL_TARGET}/kernel/drivers/input/touchscreen/
+	cp -p goodix.ko /lib/modules/${KERNEL_TARGET}/kernel/drivers/input/touchscreen/
 	# Running depmod to refresh modules dependency 
 	depmod $KERNEL_TARGET
-	echo goodix >> /etc/modules
+	grep -qw goodix /etc/modules ||
+	    echo goodix >> /etc/modules
 	echo "###### YOU MUST RESTART AND SELECT $KERNEL_TARGET ######"
 }
 


### PR DESCRIPTION
- Stop script execution on errors
- Use the nearest APT mirror
- Try to detect kernel version automagically
- Prevent multiple lines in /etc/modules
- Small realignments
